### PR TITLE
Add exported sub-order types for ease of use by the community

### DIFF
--- a/src/order.ts
+++ b/src/order.ts
@@ -1,643 +1,230 @@
+export type OrderSession = 'NORMAL' | 'AM' | 'PM' | 'SEAMLESS';
+export type OrderDuration = 'DAY' | 'GOOD_TILL_CANCEL' | 'FILL_OR_KILL';
+export type OrderType =
+  | 'MARKET'
+  | 'LIMIT'
+  | 'STOP'
+  | 'STOP_LIMIT'
+  | 'TRAILING_STOP'
+  | 'MARKET_ON_CLOSE'
+  | 'EXERCISE'
+  | 'TRAILING_STOP_LIMIT'
+  | 'NET_DEBIT'
+  | 'NET_CREDIT'
+  | 'NET_ZERO';
+
+export type CancelTime = { date?: string; shortFormat?: boolean };
+
+export type ComplexOrderStrategyType =
+  | 'NONE'
+  | 'COVERED'
+  | 'VERTICAL'
+  | 'BACK_RATIO'
+  | 'CALENDAR'
+  | 'DIAGONAL'
+  | 'STRADDLE'
+  | 'STRANGLE'
+  | 'COLLAR_SYNTHETIC'
+  | 'BUTTERFLY'
+  | 'CONDOR'
+  | 'IRON_CONDOR'
+  | 'VERTICAL_ROLL'
+  | 'COLLAR_WITH_STOCK'
+  | 'DOUBLE_DIAGONAL'
+  | 'UNBALANCED_BUTTERFLY'
+  | 'UNBALANCED_CONDOR'
+  | 'UNBALANCED_IRON_CONDOR'
+  | 'UNBALANCED_VERTICAL_ROLL'
+  | 'CUSTOM';
+
+export type RequestedDestination =
+  | 'INET'
+  | 'ECN_ARCA'
+  | 'CBOE'
+  | 'AMEX'
+  | 'PHLX'
+  | 'ISE'
+  | 'BOX'
+  | 'NYSE'
+  | 'NASDAQ'
+  | 'BATS'
+  | 'C2'
+  | 'AUTO';
+
+export type PriceLinkBasis =
+  | 'MANUAL'
+  | 'BASE'
+  | 'TRIGGER'
+  | 'LAST'
+  | 'BID'
+  | 'ASK'
+  | 'ASK_BID'
+  | 'MARK'
+  | 'AVERAGE';
+
+export type PriceLinkType = 'VALUE' | 'PERCENT' | 'TICK';
+
+export type StopType = 'STANDARD' | 'BID' | 'ASK' | 'LAST' | 'MARK';
+
+export type TaxLotMethod =
+  | 'FIFO'
+  | 'LIFO'
+  | 'HIGH_COST'
+  | 'LOW_COST'
+  | 'AVERAGE_COST'
+  | 'SPECIFIC_LOT';
+
+export type AssetType =
+  | 'EQUITY'
+  | 'OPTION'
+  | 'INDEX'
+  | 'MUTUAL_FUND'
+  | 'CASH_EQUIVALENT'
+  | 'FIXED_INCOME'
+  | 'CURRENCY';
+
+export type Instruction =
+  | 'BUY'
+  | 'SELL'
+  | 'BUY_TO_COVER'
+  | 'SELL_SHORT'
+  | 'BUY_TO_OPEN'
+  | 'BUY_TO_CLOSE'
+  | 'SELL_TO_OPEN'
+  | 'SELL_TO_CLOSE'
+  | 'EXCHANGE';
+
+export type PositionEffect = 'OPENING' | 'CLOSING' | 'AUTOMATIC';
+export type QuantityType = 'ALL_SHARES' | 'DOLLARS' | 'SHARES';
+export type SpecialInstruction =
+  | 'ALL_OR_NONE'
+  | 'DO_NOT_REDUCE'
+  | 'ALL_OR_NONE_DO_NOT_REDUCE';
+
+export type OrderStatus =
+  | 'AWAITING_PARENT_ORDER'
+  | 'AWAITING_CONDITION'
+  | 'AWAITING_MANUAL_REVIEW'
+  | 'ACCEPTED'
+  | 'AWAITING_UR_OUT'
+  | 'PENDING_ACTIVATION'
+  | 'QUEUED'
+  | 'WORKING'
+  | 'REJECTED'
+  | 'PENDING_CANCEL'
+  | 'CANCELED'
+  | 'PENDING_REPLACE'
+  | 'REPLACED'
+  | 'FILLED'
+  | 'EXPIRED';
+
+export type ActivityType = 'EXECUTION' | 'ORDER_ACTION';
+
+export type OrderStrategyType = 'SINGLE' | 'OCO' | 'TRIGGER';
+
 export interface Order {
-  session?: 'NORMAL' | 'AM' | 'PM' | 'SEAMLESS';
-  duration?: 'DAY' | 'GOOD_TILL_CANCEL' | 'FILL_OR_KILL';
-  orderType?:
-    | 'MARKET'
-    | 'LIMIT'
-    | 'STOP'
-    | 'STOP_LIMIT'
-    | 'TRAILING_STOP'
-    | 'MARKET_ON_CLOSE'
-    | 'EXERCISE'
-    | 'TRAILING_STOP_LIMIT'
-    | 'NET_DEBIT'
-    | 'NET_CREDIT'
-    | 'NET_ZERO';
-  cancelTime?: { date?: string; shortFormat?: boolean };
-  complexOrderStrategyType?:
-    | 'NONE'
-    | 'COVERED'
-    | 'VERTICAL'
-    | 'BACK_RATIO'
-    | 'CALENDAR'
-    | 'DIAGONAL'
-    | 'STRADDLE'
-    | 'STRANGLE'
-    | 'COLLAR_SYNTHETIC'
-    | 'BUTTERFLY'
-    | 'CONDOR'
-    | 'IRON_CONDOR'
-    | 'VERTICAL_ROLL'
-    | 'COLLAR_WITH_STOCK'
-    | 'DOUBLE_DIAGONAL'
-    | 'UNBALANCED_BUTTERFLY'
-    | 'UNBALANCED_CONDOR'
-    | 'UNBALANCED_IRON_CONDOR'
-    | 'UNBALANCED_VERTICAL_ROLL'
-    | 'CUSTOM';
+  session?: OrderSession;
+  duration?: OrderDuration;
+  orderType?: OrderType;
+  cancelTime?: CancelTime;
+  complexOrderStrategyType?: ComplexOrderStrategyType;
   quantity?: number;
   filledQuantity?: number;
   remainingQuantity?: number;
-  requestedDestination?:
-    | 'INET'
-    | 'ECN_ARCA'
-    | 'CBOE'
-    | 'AMEX'
-    | 'PHLX'
-    | 'ISE'
-    | 'BOX'
-    | 'NYSE'
-    | 'NASDAQ'
-    | 'BATS'
-    | 'C2'
-    | 'AUTO';
+  requestedDestination?: RequestedDestination;
   destinationLinkName?: string;
   releaseTime?: string;
   stopPrice?: number;
-  stopPriceLinkBasis?:
-    | 'MANUAL'
-    | 'BASE'
-    | 'TRIGGER'
-    | 'LAST'
-    | 'BID'
-    | 'ASK'
-    | 'ASK_BID'
-    | 'MARK'
-    | 'AVERAGE';
-  stopPriceLinkType?: 'VALUE' | 'PERCENT' | 'TICK';
+  stopPriceLinkBasis?: PriceLinkBasis;
+  stopPriceLinkType?: PriceLinkType;
   stopPriceOffset?: number;
-  stopType?: 'STANDARD' | 'BID' | 'ASK' | 'LAST' | 'MARK';
-  priceLinkBasis?:
-    | 'MANUAL'
-    | 'BASE'
-    | 'TRIGGER'
-    | 'LAST'
-    | 'BID'
-    | 'ASK'
-    | 'ASK_BID'
-    | 'MARK'
-    | 'AVERAGE';
-  priceLinkType?: 'VALUE' | 'PERCENT' | 'TICK';
+  stopType?: StopType;
+  priceLinkBasis?: PriceLinkBasis;
+  priceLinkType?: PriceLinkType;
   price?: number;
-  taxLotMethod?:
-    | 'FIFO'
-    | 'LIFO'
-    | 'HIGH_COST'
-    | 'LOW_COST'
-    | 'AVERAGE_COST'
-    | 'SPECIFIC_LOT';
+  taxLotMethod?: TaxLotMethod;
   orderLegCollection?: {
-    orderLegType?:
-      | 'EQUITY'
-      | 'OPTION'
-      | 'INDEX'
-      | 'MUTUAL_FUND'
-      | 'CASH_EQUIVALENT'
-      | 'FIXED_INCOME'
-      | 'CURRENCY';
+    orderLegType?: AssetType;
     legId?: number;
     instrument?: {
-      assetType?:
-        | 'EQUITY'
-        | 'OPTION'
-        | 'INDEX'
-        | 'MUTUAL_FUND'
-        | 'CASH_EQUIVALENT'
-        | 'FIXED_INCOME'
-        | 'CURRENCY';
+      assetType?: AssetType;
       cusip?: string;
       symbol?: string;
       description?: string;
     };
-    instruction?:
-      | 'BUY'
-      | 'SELL'
-      | 'BUY_TO_COVER'
-      | 'SELL_SHORT'
-      | 'BUY_TO_OPEN'
-      | 'BUY_TO_CLOSE'
-      | 'SELL_TO_OPEN'
-      | 'SELL_TO_CLOSE'
-      | 'EXCHANGE';
-    positionEffect?: 'OPENING' | 'CLOSING' | 'AUTOMATIC';
+    instruction?: Instruction;
+    positionEffect?: PositionEffect;
     quantity?: number;
-    quantityType?: 'ALL_SHARES' | 'DOLLARS' | 'SHARES';
+    quantityType?: QuantityType;
   }[];
   activationPrice?: number;
-  specialInstruction?:
-    | 'ALL_OR_NONE'
-    | 'DO_NOT_REDUCE'
-    | 'ALL_OR_NONE_DO_NOT_REDUCE';
-  orderStrategyType?: 'SINGLE' | 'OCO' | 'TRIGGER';
+  specialInstruction?: SpecialInstruction;
   orderId?: number;
   cancelable?: boolean;
   editable?: boolean;
-  status?:
-    | 'AWAITING_PARENT_ORDER'
-    | 'AWAITING_CONDITION'
-    | 'AWAITING_MANUAL_REVIEW'
-    | 'ACCEPTED'
-    | 'AWAITING_UR_OUT'
-    | 'PENDING_ACTIVATION'
-    | 'QUEUED'
-    | 'WORKING'
-    | 'REJECTED'
-    | 'PENDING_CANCEL'
-    | 'CANCELED'
-    | 'PENDING_REPLACE'
-    | 'REPLACED'
-    | 'FILLED'
-    | 'EXPIRED';
+  status?: OrderStatus;
   enteredTime?: string;
   closeTime?: string;
   tag?: string;
   accountId?: number;
   orderActivityCollection?: {
-    activityType?: 'EXECUTION' | 'ORDER_ACTION';
+    activityType?: ActivityType;
   }[];
-  replacingOrderCollection?: any[];
-  childOrderStrategies?: any[];
+  replacingOrderCollection?: Order[];
+  childOrderStrategies?: Order[];
   statusDescription?: string;
 }
 export interface SavedOrder {
-  session?: 'NORMAL' | 'AM' | 'PM' | 'SEAMLESS';
-  duration?: 'DAY' | 'GOOD_TILL_CANCEL' | 'FILL_OR_KILL';
-  orderType?:
-    | 'MARKET'
-    | 'LIMIT'
-    | 'STOP'
-    | 'STOP_LIMIT'
-    | 'TRAILING_STOP'
-    | 'MARKET_ON_CLOSE'
-    | 'EXERCISE'
-    | 'TRAILING_STOP_LIMIT'
-    | 'NET_DEBIT'
-    | 'NET_CREDIT'
-    | 'NET_ZERO';
-  cancelTime?: { date?: string; shortFormat?: boolean };
-  complexOrderStrategyType?:
-    | 'NONE'
-    | 'COVERED'
-    | 'VERTICAL'
-    | 'BACK_RATIO'
-    | 'CALENDAR'
-    | 'DIAGONAL'
-    | 'STRADDLE'
-    | 'STRANGLE'
-    | 'COLLAR_SYNTHETIC'
-    | 'BUTTERFLY'
-    | 'CONDOR'
-    | 'IRON_CONDOR'
-    | 'VERTICAL_ROLL'
-    | 'COLLAR_WITH_STOCK'
-    | 'DOUBLE_DIAGONAL'
-    | 'UNBALANCED_BUTTERFLY'
-    | 'UNBALANCED_CONDOR'
-    | 'UNBALANCED_IRON_CONDOR'
-    | 'UNBALANCED_VERTICAL_ROLL'
-    | 'CUSTOM';
+  session?: OrderSession;
+  duration?: OrderDuration;
+  orderType?: OrderType;
+  cancelTime?: CancelTime;
+  complexOrderStrategyType?: ComplexOrderStrategyType;
   quantity?: number;
   filledQuantity?: number;
   remainingQuantity?: number;
-  requestedDestination?:
-    | 'INET'
-    | 'ECN_ARCA'
-    | 'CBOE'
-    | 'AMEX'
-    | 'PHLX'
-    | 'ISE'
-    | 'BOX'
-    | 'NYSE'
-    | 'NASDAQ'
-    | 'BATS'
-    | 'C2'
-    | 'AUTO';
+  requestedDestination?: RequestedDestination;
   destinationLinkName?: string;
   releaseTime?: string;
   stopPrice?: number;
-  stopPriceLinkBasis?:
-    | 'MANUAL'
-    | 'BASE'
-    | 'TRIGGER'
-    | 'LAST'
-    | 'BID'
-    | 'ASK'
-    | 'ASK_BID'
-    | 'MARK'
-    | 'AVERAGE';
-  stopPriceLinkType?: 'VALUE' | 'PERCENT' | 'TICK';
+  stopPriceLinkBasis?: PriceLinkBasis;
+  stopPriceLinkType?: PriceLinkType;
   stopPriceOffset?: number;
-  stopType?: 'STANDARD' | 'BID' | 'ASK' | 'LAST' | 'MARK';
-  priceLinkBasis?:
-    | 'MANUAL'
-    | 'BASE'
-    | 'TRIGGER'
-    | 'LAST'
-    | 'BID'
-    | 'ASK'
-    | 'ASK_BID'
-    | 'MARK'
-    | 'AVERAGE';
-  priceLinkType?: 'VALUE' | 'PERCENT' | 'TICK';
+  stopType?: StopType;
+  priceLinkBasis?: PriceLinkBasis;
+  priceLinkType?: PriceLinkType;
   price?: number;
-  taxLotMethod?:
-    | 'FIFO'
-    | 'LIFO'
-    | 'HIGH_COST'
-    | 'LOW_COST'
-    | 'AVERAGE_COST'
-    | 'SPECIFIC_LOT';
+  taxLotMethod?: TaxLotMethod;
   orderLegCollection?: {
-    orderLegType?:
-      | 'EQUITY'
-      | 'OPTION'
-      | 'INDEX'
-      | 'MUTUAL_FUND'
-      | 'CASH_EQUIVALENT'
-      | 'FIXED_INCOME'
-      | 'CURRENCY';
+    orderLegType?: AssetType;
     legId?: number;
     instrument?: {
-      assetType?:
-        | 'EQUITY'
-        | 'OPTION'
-        | 'INDEX'
-        | 'MUTUAL_FUND'
-        | 'CASH_EQUIVALENT'
-        | 'FIXED_INCOME'
-        | 'CURRENCY';
+      assetType?: AssetType;
       cusip?: string;
       symbol?: string;
       description?: string;
     };
-    instruction?:
-      | 'BUY'
-      | 'SELL'
-      | 'BUY_TO_COVER'
-      | 'SELL_SHORT'
-      | 'BUY_TO_OPEN'
-      | 'BUY_TO_CLOSE'
-      | 'SELL_TO_OPEN'
-      | 'SELL_TO_CLOSE'
-      | 'EXCHANGE';
-    positionEffect?: 'OPENING' | 'CLOSING' | 'AUTOMATIC';
+    instruction?: Instruction;
+    positionEffect?: PositionEffect;
     quantity?: number;
-    quantityType?: 'ALL_SHARES' | 'DOLLARS' | 'SHARES';
+    quantityType?: QuantityType;
   }[];
   activationPrice?: number;
-  specialInstruction?:
-    | 'ALL_OR_NONE'
-    | 'DO_NOT_REDUCE'
-    | 'ALL_OR_NONE_DO_NOT_REDUCE';
-  orderStrategyType?: 'SINGLE' | 'OCO' | 'TRIGGER';
+  specialInstruction?: SpecialInstruction;
+  orderStrategyType?: OrderStrategyType;
   orderId?: number;
   cancelable?: boolean;
   editable?: boolean;
-  status?:
-    | 'AWAITING_PARENT_ORDER'
-    | 'AWAITING_CONDITION'
-    | 'AWAITING_MANUAL_REVIEW'
-    | 'ACCEPTED'
-    | 'AWAITING_UR_OUT'
-    | 'PENDING_ACTIVATION'
-    | 'QUEUED'
-    | 'WORKING'
-    | 'REJECTED'
-    | 'PENDING_CANCEL'
-    | 'CANCELED'
-    | 'PENDING_REPLACE'
-    | 'REPLACED'
-    | 'FILLED'
-    | 'EXPIRED';
+  status?: OrderStatus;
   enteredTime?: string;
   closeTime?: string;
   tag?: string;
   accountId?: number;
   orderActivityCollection?: {
-    activityType?: 'EXECUTION' | 'ORDER_ACTION';
+    activityType?: ActivityType;
   }[];
-  replacingOrderCollection?: {
-    session?: 'NORMAL' | 'AM' | 'PM' | 'SEAMLESS';
-    duration?: 'DAY' | 'GOOD_TILL_CANCEL' | 'FILL_OR_KILL';
-    orderType?:
-      | 'MARKET'
-      | 'LIMIT'
-      | 'STOP'
-      | 'STOP_LIMIT'
-      | 'TRAILING_STOP'
-      | 'MARKET_ON_CLOSE'
-      | 'EXERCISE'
-      | 'TRAILING_STOP_LIMIT'
-      | 'NET_DEBIT'
-      | 'NET_CREDIT'
-      | 'NET_ZERO';
-    cancelTime?: { date?: string; shortFormat?: boolean };
-    complexOrderStrategyType?:
-      | 'NONE'
-      | 'COVERED'
-      | 'VERTICAL'
-      | 'BACK_RATIO'
-      | 'CALENDAR'
-      | 'DIAGONAL'
-      | 'STRADDLE'
-      | 'STRANGLE'
-      | 'COLLAR_SYNTHETIC'
-      | 'BUTTERFLY'
-      | 'CONDOR'
-      | 'IRON_CONDOR'
-      | 'VERTICAL_ROLL'
-      | 'COLLAR_WITH_STOCK'
-      | 'DOUBLE_DIAGONAL'
-      | 'UNBALANCED_BUTTERFLY'
-      | 'UNBALANCED_CONDOR'
-      | 'UNBALANCED_IRON_CONDOR'
-      | 'UNBALANCED_VERTICAL_ROLL'
-      | 'CUSTOM';
-    quantity?: number;
-    filledQuantity?: number;
-    remainingQuantity?: number;
-    requestedDestination?:
-      | 'INET'
-      | 'ECN_ARCA'
-      | 'CBOE'
-      | 'AMEX'
-      | 'PHLX'
-      | 'ISE'
-      | 'BOX'
-      | 'NYSE'
-      | 'NASDAQ'
-      | 'BATS'
-      | 'C2'
-      | 'AUTO';
-    destinationLinkName?: string;
-    releaseTime?: string;
-    stopPrice?: number;
-    stopPriceLinkBasis?:
-      | 'MANUAL'
-      | 'BASE'
-      | 'TRIGGER'
-      | 'LAST'
-      | 'BID'
-      | 'ASK'
-      | 'ASK_BID'
-      | 'MARK'
-      | 'AVERAGE';
-    stopPriceLinkType?: 'VALUE' | 'PERCENT' | 'TICK';
-    stopPriceOffset?: number;
-    stopType?: 'STANDARD' | 'BID' | 'ASK' | 'LAST' | 'MARK';
-    priceLinkBasis?:
-      | 'MANUAL'
-      | 'BASE'
-      | 'TRIGGER'
-      | 'LAST'
-      | 'BID'
-      | 'ASK'
-      | 'ASK_BID'
-      | 'MARK'
-      | 'AVERAGE';
-    priceLinkType?: 'VALUE' | 'PERCENT' | 'TICK';
-    price?: number;
-    taxLotMethod?:
-      | 'FIFO'
-      | 'LIFO'
-      | 'HIGH_COST'
-      | 'LOW_COST'
-      | 'AVERAGE_COST'
-      | 'SPECIFIC_LOT';
-    orderLegCollection?: {
-      orderLegType?:
-        | 'EQUITY'
-        | 'OPTION'
-        | 'INDEX'
-        | 'MUTUAL_FUND'
-        | 'CASH_EQUIVALENT'
-        | 'FIXED_INCOME'
-        | 'CURRENCY';
-      legId?: number;
-      instrument?: {
-        assetType?:
-          | 'EQUITY'
-          | 'OPTION'
-          | 'INDEX'
-          | 'MUTUAL_FUND'
-          | 'CASH_EQUIVALENT'
-          | 'FIXED_INCOME'
-          | 'CURRENCY';
-        cusip?: string;
-        symbol?: string;
-        description?: string;
-      };
-      instruction?:
-        | 'BUY'
-        | 'SELL'
-        | 'BUY_TO_COVER'
-        | 'SELL_SHORT'
-        | 'BUY_TO_OPEN'
-        | 'BUY_TO_CLOSE'
-        | 'SELL_TO_OPEN'
-        | 'SELL_TO_CLOSE'
-        | 'EXCHANGE';
-      positionEffect?: 'OPENING' | 'CLOSING' | 'AUTOMATIC';
-      quantity?: number;
-      quantityType?: 'ALL_SHARES' | 'DOLLARS' | 'SHARES';
-    }[];
-    activationPrice?: number;
-    specialInstruction?:
-      | 'ALL_OR_NONE'
-      | 'DO_NOT_REDUCE'
-      | 'ALL_OR_NONE_DO_NOT_REDUCE';
-    orderStrategyType?: 'SINGLE' | 'OCO' | 'TRIGGER';
-    orderId?: number;
-    cancelable?: boolean;
-    editable?: boolean;
-    status?:
-      | 'AWAITING_PARENT_ORDER'
-      | 'AWAITING_CONDITION'
-      | 'AWAITING_MANUAL_REVIEW'
-      | 'ACCEPTED'
-      | 'AWAITING_UR_OUT'
-      | 'PENDING_ACTIVATION'
-      | 'QUEUED'
-      | 'WORKING'
-      | 'REJECTED'
-      | 'PENDING_CANCEL'
-      | 'CANCELED'
-      | 'PENDING_REPLACE'
-      | 'REPLACED'
-      | 'FILLED'
-      | 'EXPIRED';
-    enteredTime?: string;
-    closeTime?: string;
-    tag?: string;
-    accountId?: number;
-    orderActivityCollection?: {
-      activityType?: 'EXECUTION' | 'ORDER_ACTION';
-    }[];
-    replacingOrderCollection?: any[];
-    childOrderStrategies?: any[];
-    statusDescription?: string;
-  }[];
-  childOrderStrategies?: {
-    session?: 'NORMAL' | 'AM' | 'PM' | 'SEAMLESS';
-    duration?: 'DAY' | 'GOOD_TILL_CANCEL' | 'FILL_OR_KILL';
-    orderType?:
-      | 'MARKET'
-      | 'LIMIT'
-      | 'STOP'
-      | 'STOP_LIMIT'
-      | 'TRAILING_STOP'
-      | 'MARKET_ON_CLOSE'
-      | 'EXERCISE'
-      | 'TRAILING_STOP_LIMIT'
-      | 'NET_DEBIT'
-      | 'NET_CREDIT'
-      | 'NET_ZERO';
-    cancelTime?: { date?: string; shortFormat?: boolean };
-    complexOrderStrategyType?:
-      | 'NONE'
-      | 'COVERED'
-      | 'VERTICAL'
-      | 'BACK_RATIO'
-      | 'CALENDAR'
-      | 'DIAGONAL'
-      | 'STRADDLE'
-      | 'STRANGLE'
-      | 'COLLAR_SYNTHETIC'
-      | 'BUTTERFLY'
-      | 'CONDOR'
-      | 'IRON_CONDOR'
-      | 'VERTICAL_ROLL'
-      | 'COLLAR_WITH_STOCK'
-      | 'DOUBLE_DIAGONAL'
-      | 'UNBALANCED_BUTTERFLY'
-      | 'UNBALANCED_CONDOR'
-      | 'UNBALANCED_IRON_CONDOR'
-      | 'UNBALANCED_VERTICAL_ROLL'
-      | 'CUSTOM';
-    quantity?: number;
-    filledQuantity?: number;
-    remainingQuantity?: number;
-    requestedDestination?:
-      | 'INET'
-      | 'ECN_ARCA'
-      | 'CBOE'
-      | 'AMEX'
-      | 'PHLX'
-      | 'ISE'
-      | 'BOX'
-      | 'NYSE'
-      | 'NASDAQ'
-      | 'BATS'
-      | 'C2'
-      | 'AUTO';
-    destinationLinkName?: string;
-    releaseTime?: string;
-    stopPrice?: number;
-    stopPriceLinkBasis?:
-      | 'MANUAL'
-      | 'BASE'
-      | 'TRIGGER'
-      | 'LAST'
-      | 'BID'
-      | 'ASK'
-      | 'ASK_BID'
-      | 'MARK'
-      | 'AVERAGE';
-    stopPriceLinkType?: 'VALUE' | 'PERCENT' | 'TICK';
-    stopPriceOffset?: number;
-    stopType?: 'STANDARD' | 'BID' | 'ASK' | 'LAST' | 'MARK';
-    priceLinkBasis?:
-      | 'MANUAL'
-      | 'BASE'
-      | 'TRIGGER'
-      | 'LAST'
-      | 'BID'
-      | 'ASK'
-      | 'ASK_BID'
-      | 'MARK'
-      | 'AVERAGE';
-    priceLinkType?: 'VALUE' | 'PERCENT' | 'TICK';
-    price?: number;
-    taxLotMethod?:
-      | 'FIFO'
-      | 'LIFO'
-      | 'HIGH_COST'
-      | 'LOW_COST'
-      | 'AVERAGE_COST'
-      | 'SPECIFIC_LOT';
-    orderLegCollection?: {
-      orderLegType?:
-        | 'EQUITY'
-        | 'OPTION'
-        | 'INDEX'
-        | 'MUTUAL_FUND'
-        | 'CASH_EQUIVALENT'
-        | 'FIXED_INCOME'
-        | 'CURRENCY';
-      legId?: number;
-      instrument?: {
-        assetType?:
-          | 'EQUITY'
-          | 'OPTION'
-          | 'INDEX'
-          | 'MUTUAL_FUND'
-          | 'CASH_EQUIVALENT'
-          | 'FIXED_INCOME'
-          | 'CURRENCY';
-        cusip?: string;
-        symbol?: string;
-        description?: string;
-      };
-      instruction?:
-        | 'BUY'
-        | 'SELL'
-        | 'BUY_TO_COVER'
-        | 'SELL_SHORT'
-        | 'BUY_TO_OPEN'
-        | 'BUY_TO_CLOSE'
-        | 'SELL_TO_OPEN'
-        | 'SELL_TO_CLOSE'
-        | 'EXCHANGE';
-      positionEffect?: 'OPENING' | 'CLOSING' | 'AUTOMATIC';
-      quantity?: number;
-      quantityType?: 'ALL_SHARES' | 'DOLLARS' | 'SHARES';
-    }[];
-    activationPrice?: number;
-    specialInstruction?:
-      | 'ALL_OR_NONE'
-      | 'DO_NOT_REDUCE'
-      | 'ALL_OR_NONE_DO_NOT_REDUCE';
-    orderStrategyType?: 'SINGLE' | 'OCO' | 'TRIGGER';
-    orderId?: number;
-    cancelable?: boolean;
-    editable?: boolean;
-    status?:
-      | 'AWAITING_PARENT_ORDER'
-      | 'AWAITING_CONDITION'
-      | 'AWAITING_MANUAL_REVIEW'
-      | 'ACCEPTED'
-      | 'AWAITING_UR_OUT'
-      | 'PENDING_ACTIVATION'
-      | 'QUEUED'
-      | 'WORKING'
-      | 'REJECTED'
-      | 'PENDING_CANCEL'
-      | 'CANCELED'
-      | 'PENDING_REPLACE'
-      | 'REPLACED'
-      | 'FILLED'
-      | 'EXPIRED';
-    enteredTime?: string;
-    closeTime?: string;
-    tag?: string;
-    accountId?: number;
-    orderActivityCollection?: {
-      activityType?: 'EXECUTION' | 'ORDER_ACTION';
-    }[];
-    replacingOrderCollection?: any[];
-    childOrderStrategies?: any[];
-    statusDescription?: string;
-  }[];
+  replacingOrderCollection?: SavedOrder[];
+  childOrderStrategies?: SavedOrder[];
   statusDescription?: string;
   savedOrderId?: number;
   savedTime?: string;


### PR DESCRIPTION
I was wondering if you would accept changes such as this. People might be using your package for complex needs and sometimes it's beneficial to pull in specific types into your project for nuanced logic before submitting an order. Another benefit here is it makes the `Order` and `SavedOrder` much easier to read and reason about.

Thanks again for all your hard work in the initial documentation of these types! It's very helpful. Let me know if there is anything else I need to do to make this merge ready.